### PR TITLE
Fix typo in usage example

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ var testView = React.createClass({
       <View>
         <HTMLWebView
             style={{width: 300}}
-            html={this.state.htmlContnets}
+            html={this.state.htmlContents}
             makeSafe={true}
             autoHeight={true}
             onLink={this.onLink}/>


### PR DESCRIPTION
It said 'contnets', and not 'contents' :smile:
